### PR TITLE
Mixed improvements

### DIFF
--- a/hypoddpy/hypodd_compiler.py
+++ b/hypoddpy/hypodd_compiler.py
@@ -269,8 +269,11 @@ class HypoDDCompiler(object):
             open_file.write(self.hypodd_inc_file)
         # Compile it.
         self.log("Compiling HypoDD ...")
-        retcode = subprocess.Popen("make",
-            cwd=self.paths["make_directory"]).wait()
+        sub = subprocess.Popen(
+            "make", cwd=self.paths["make_directory"], stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        self.log(sub.stdout.read())
+        retcode = sub.wait()
         if retcode != 0:
             msg = "Problem compiling HypoDD."
             raise HypoDDCompilationError(msg)

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -1236,6 +1236,8 @@ class HypoDDRelocator(object):
         Creates some plots of the relocated event Catalog.
         """
         import matplotlib.pylab as plt
+        from matplotlib.cm import get_cmap
+        from matplotlib.colors import ColorConverter
 
         catalog = self.output_catalog
         # Generate the output plot filenames.
@@ -1262,8 +1264,8 @@ class HypoDDRelocator(object):
         # magenta: relocated with cluster id 7
         # brown: relocated with cluster id 8
         # lime: relocated with cluster id >8 or undetermined cluster_id
-        color_map = ["grey", "red", "green", "blue", "yellow", "orange",
-            "cyan", "magenta", "brown", "lime"]
+        color_invalid = ColorConverter().to_rgba("grey")
+        cmap = get_cmap("Paired", 12)
 
         colors = []
         magnitudes = []
@@ -1281,18 +1283,18 @@ class HypoDDRelocator(object):
             # Use color to Code the different events. Colorcode by event
             # cluster or indicate if an event did not get relocated.
             if event.origins[-1].method_id is None or \
-               event.origins[-1].method_id.resource_id != "HypoDD":
-                colors.append(color_map[0])
+               "HYPODD" not in str(event.origins[-1].method_id).upper():
+                colors.append(color_invalid)
             # Otherwise get the cluster id, stored in the comments.
             else:
-                cluster_id = 9
                 for comment in event.origins[-1].comments:
                     comment = comment.text
-                    if "HypoDD cluster id" in comment:
+                    if comment and "HypoDD cluster id" in comment:
                         cluster_id = int(comment.split(":")[-1])
-                if cluster_id > 9:
-                    cluster_id = 9
-                colors.append(color_map[cluster_id])
+                        break
+                else:
+                    cluster_id = 0
+                colors.append(cmap(int(cluster_id)))
 
         # Plot the original event location.
         plt.subplot(221)

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -339,8 +339,7 @@ class HypoDDRelocator(object):
                                  minute=event["origin_time"].minute,
                                  # Seconds + microseconds
                                  second=float(event["origin_time"].second) +
-                                 (float(event["origin_time"]
-                                  .microsecond) / 1000.0),
+                                 (event["origin_time"].microsecond / 1e6),
                                  latitude=event["origin_latitude"],
                                  longitude=event["origin_longitude"],
                                  # QuakeML depth is in meters. Convert to km.

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -605,12 +605,22 @@ class HypoDDRelocator(object):
         """
         Compiles HypoDD and ph2dt using
         """
-        self.log("Initating HypoDD compilation...")
-        compiler = HypoDDCompiler(working_dir=self.working_dir,
-                                  log_function=self.log)
-        compiler.configure(MAXEVE=1.2 * len(self.events),
-                           MAXSTA=1.2 * len(self.stations))
-        compiler.make()
+        logfile = os.path.join(self.working_dir, "compilation.log")
+        self.log("Initating HypoDD compilation (logfile: %s)..." % logfile)
+        with open(logfile, "w") as fh:
+            def logfunc(line):
+                fh.write(line)
+                fh.write(os.linesep)
+            compiler = HypoDDCompiler(working_dir=self.working_dir,
+                                      log_function=logfunc)
+            compiler.configure(MAXEVE=len(self.events) + 30,
+                               #MAXEVE0=len(self.events) + 30,
+                               MAXEVE0=200,
+                               MAXDATA=100000,
+                               MAXDATA0=60000,
+                               MAXCL=20,
+                               MAXSTA=len(self.stations) + 10)
+            compiler.make()
 
     def _run_hypodd(self):
         """

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -485,6 +485,8 @@ class HypoDDRelocator(object):
                     discarded_picks += 0
                     continue
                 current_event["picks"].append(current_pick)
+        # Sort events by origin time
+        self.events.sort(key=lambda event: event["origin_time"])
         # Serialize the event dict. Copy it so the times can be converted to
         # strings.
         events = copy.deepcopy(self.events)

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -983,6 +983,12 @@ class HypoDDRelocator(object):
                                trace.stats.endtime < min_endtime_st_2:
                                 st_2.remove(trace)
 
+                        # cleanup merges, in case the event is included in
+                        # multiple traces (happens for events with very close
+                        # origin times)
+                        st_1.merge(-1)
+                        st_2.merge(-1)
+
                         if len(st_1) > 1:
                             msg = "More than one matching trace found for {pick}"
                             self.log(msg.format(pick=str(pick_1)), level="warning")

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -412,7 +412,7 @@ class HypoDDRelocator(object):
         for event in catalog:
             current_event = {}
             self.events.append(current_event)
-            current_event["event_id"] = event.resource_id.resource_id
+            current_event["event_id"] = str(event.resource_id)
             # Take the value from the first event.
             current_event["magnitude"] = event.magnitudes[0].mag
             # Always take the first origin.
@@ -1224,8 +1224,8 @@ class HypoDDRelocator(object):
                 new_origin.method_id = "HypoDD"
                 # Put the cluster id in the comments to be able to use it later
                 # on.
-                new_origin.comments.append(Comment("HypoDD cluster id: %i" %
-                    cluster_id))
+                new_origin.comments.append(Comment(
+                    text="HypoDD cluster id: %i" % cluster_id))
                 event.origins.append(new_origin)
         cat.write(self.output_event_file, format="quakeml")
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ AUTHOR_EMAIL = 'krischer@geophysik.uni-muenchen.de'
 URL = 'None so far...'
 LICENSE = 'GNU General Public License, version 3 (GPLv3)'
 KEYWORDS = ['seismology', 'earthquakes', 'relocation']
-INSTALL_REQUIRES = ['obspy.core', 'obspy.mseed', 'obspy.signal', 'progressbar']
+INSTALL_REQUIRES = ['obspy', 'progressbar']
 ENTRY_POINTS = {}
 
 


### PR DESCRIPTION
Here's a PR from a collection of commits that I made during my last runs of HypoDDpy, in order to keep improvements flowing back to the main repo..

I also saw that @ThomasLecocq has some minor fixes/improvements on his master branch.. we should aim to get them into the main repo as well, I think..

Besides some small bug fixes and edge case fixes it contains some refactoring (including very minor API changes).
The biggest change is the possibility to save cross correlation results (in json format for simplicity) remembering the combination of two pick IDs. I found this useful because this is usually the most time consuming step in the process and usually one wants to try different weighting settings and have several runs with different parameter settings.

One other addition is the possibility to have a custom weighting function so that each individual pick can get a custom weight.

Full list of changes:
fixes:
  - origin time seconds (microseconds were divided by 1000 to get seconds)
  - do a cleanup merge on waveform files
    (event waveform data can be included in
    multiple files in case of event based waveform files and events that are
    close in origin time. a cleanup merge should result in a single trace even in
    this case.event waveform data can be included in multiple files in case of
    event based waveform files and events that are close in origin time. a
    cleanup merge should result in a single trace even in this case.)
  - minor updates for changes in obspy (single package structure etc.)

refactoring:
  - move hypodd compilation output from stdout to log file
    (to make stdout more concise, compilation log is only needed when problems in
     compilation occur)
  - untangle method for plot creation

improvements:
  - remember pick correlation results:
    makes it possible to reuse cross correlation results in consecutive runs with
    changes in hypoDD configuration. cross correlation results are saved using
    the pick ids of both involved picks.
    Don't discard already present cross correlation results when loading other
    cross correlation results from file, just update the dictionaries with the
    new information.
    Add option to save cross correlation results in relocation, right after
    relocation (to save results before possible `raise` during subsequent
    relocation).
  - add a mechanism to weight individual picks:
    user can provide a function that returns the pick weight based on station id,
    phase type, pick time and pick uncertainty
  - sort events by origin time before enumerating them for hypodd
  - change color map in plotting (to "paired")
