### PR TITLE
Update obspy api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If yes, consider citing this software! Just click on this button here to get all
 * NumPy
 * matplotlib
 * progressbar
-* A recent [ObsPy](http://obspy.org) version
+* [ObsPy](http://obspy.org) (Tested on 1.0.2)
 
 ### Installation
 hypoDDpy currently works with HypoDD 2.1b which you will have to acquire

--- a/hypoddpy/hypodd_compiler.py
+++ b/hypoddpy/hypodd_compiler.py
@@ -24,6 +24,10 @@ import tarfile
 # Specify the HypoDD version to be compiled.
 HYPODD_ARCHIVE = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src',
     'HYPODD_2.1b.tar.gz'))
+
+# Note this Hash is from the tar.gz file you got, either change this to your
+# correct one using the function call md5.md5(open_file.read()).hexdigest()
+# or simply comment out the line: if md5_hash != HYPODD_MD5_HASH:    
 HYPODD_MD5_HASH = "ac7fb5829abef23aa91f1f8a115e2b45"
 
 

--- a/hypoddpy/hypodd_relocator.py
+++ b/hypoddpy/hypodd_relocator.py
@@ -5,10 +5,10 @@ import json
 import logging
 import math
 from obspy.core import read, Stream, UTCDateTime
-from obspy.core.event import Catalog, Comment, Origin, readEvents, \
+from obspy.core.event import Catalog, Comment, Origin, read_events, \
     ResourceIdentifier
-from obspy.signal import xcorrPickCorrection
-from obspy.xseed import Parser
+from obspy.signal.cross_correlation import xcorr_pick_correction
+from obspy.io.xseed import Parser
 import os
 import progressbar
 import shutil
@@ -73,7 +73,7 @@ class HypoDDRelocator(object):
             cc_s_phase_weighting[phase] = float(
                 cc_s_phase_weighting.get(phase, 0.0))
         # set an equal phase weighting scheme by uncertainty
-        self.phase_weighting = lambda (sta_id, ph_type, time, uncertainty): 1.0
+        self.phase_weighting = lambda sta_id, ph_type, time, uncertainty: 1.0
         # Set the cross correlation parameters.
         self.cc_param = {
             "cc_time_before": cc_time_before,
@@ -423,7 +423,7 @@ class HypoDDRelocator(object):
         self.log("Reading all events...")
         catalog = Catalog()
         for event in self.event_files:
-            catalog += readEvents(event)
+            catalog += read_events(event)
         self.events = []
         # Keep track of the number of discarded picks.
         discarded_picks = 0
@@ -1057,7 +1057,7 @@ class HypoDDRelocator(object):
                             warnings.simplefilter("ignore")
                             try:
                                 pick2_corr, cross_corr_coeff = \
-                                    xcorrPickCorrection(
+                                    xcorr_pick_correction(
                                         pick_1["pick_time"], trace_1,
                                         pick_2["pick_time"], trace_2,
                                         t_before=self.cc_param["cc_time_before"],
@@ -1288,7 +1288,7 @@ class HypoDDRelocator(object):
         cat = Catalog()
         self.output_catalog = cat
         for filename in self.event_files:
-            cat += readEvents(filename)
+            cat += read_events(filename)
 
         with open(hypodd_reloc, "r") as open_file:
             for line in open_file:


### PR DESCRIPTION
Hi Lion, 

I am currently using this to relocate earthquakes, and there are some outdated obspy api which makes the script now running correctly. I just fixed them, and tested on obspy 1.0.2 and it works great. Thanks for the wrapper, really great!

For the changes:
**Change the outdated api that breaks the code**
1. in the hypodd_relocator.py,
     from obspy.core.event import readEvents -> read_events (also, change all the calls)
2. same script, the reading of the events from the quakeml seems changed as well:
     catalog += read_events(event) -> catalog += read_events(event).events[0]
3. same script,
     weight = phase_weighting(pick['station_id'], pick['phase'],
                                         pick['pick_time'],
                                         pick['pick_time_error'])
     changes to:
      weight = phase_weighting((pick['station_id'], pick['phase'],
                                         pick['pick_time'],
                                         pick['pick_time_error']))
4. in the hypodd_compiler.py, we need change the HYPODD_MD5_HASH field, based on the file you got, (you can print out using md5.md5(open_file.read()).hexdigest()), or comment out:
if md5_hash != HYPODD_MD5_HASH:

**Some warnings to take care:**
1. I need change from obspy.signal import xcorrPickCorrection to
from obspy.signal.cross_correlation import xcorr_pick_correction
2. from obspy.xseed import Parser to from obspy.io.xseed import Parser

**Add one comment for the md5 hash**

**Updated the README for the version of obspy**

